### PR TITLE
[MTDSA-12538] [CK] [MTDSA-12538] [CK] Fix the build error and enable v2 endpoints in API definition (except ET/Prod envrionments).

### DIFF
--- a/app/definition/ApiDefinitionFactory.scala
+++ b/app/definition/ApiDefinitionFactory.scala
@@ -57,6 +57,11 @@ class ApiDefinitionFactory @Inject() (appConfig: AppConfig) extends Logging {
             version = VERSION_1,
             status = buildAPIStatus(VERSION_1),
             endpointsEnabled = appConfig.endpointsEnabled(VERSION_1)
+          ),
+          APIVersion(
+            version = VERSION_2,
+            status = buildAPIStatus(VERSION_2),
+            endpointsEnabled = appConfig.endpointsEnabled(VERSION_2)
           )
         ),
         requiresTrust = None

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -97,6 +97,10 @@ api {
     status = "ALPHA"
     endpoints.enabled = false
   }
+  2.0 {
+    status = "BETA"
+    endpoints.enabled = true
+  }
 
   confidence-level-check {
     definition.enabled = true

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -98,8 +98,8 @@ api {
     endpoints.enabled = false
   }
   2.0 {
-    status = "BETA"
-    endpoints.enabled = true
+    status = "ALPHA"
+    endpoints.enabled = false
   }
 
   confidence-level-check {

--- a/it/config/DocumentationControllerISpec.scala
+++ b/it/config/DocumentationControllerISpec.scala
@@ -49,6 +49,11 @@ class DocumentationControllerISpec extends IntegrationBaseSpec {
       |        "version":"1.0",
       |        "status":"ALPHA",
       |        "endpointsEnabled":false
+      |      },
+      |      {
+      |        "version":"2.0",
+      |        "status":"BETA",
+      |        "endpointsEnabled":true
       |      }
       |    ]
       |  }

--- a/it/config/DocumentationControllerISpec.scala
+++ b/it/config/DocumentationControllerISpec.scala
@@ -16,6 +16,7 @@
 
 package config
 
+import definition.Versions.{VERSION_1, VERSION_2}
 import play.api.http.Status
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.WSResponse
@@ -52,8 +53,8 @@ class DocumentationControllerISpec extends IntegrationBaseSpec {
       |      },
       |      {
       |        "version":"2.0",
-      |        "status":"BETA",
-      |        "endpointsEnabled":true
+      |        "status":"ALPHA",
+      |        "endpointsEnabled":false
       |      }
       |    ]
       |  }
@@ -69,11 +70,14 @@ class DocumentationControllerISpec extends IntegrationBaseSpec {
   }
 
   "a documentation request" must {
-    "return the documentation" in {
-      val response: WSResponse = await(buildRequest("/api/conf/1.0/application.raml").get())
-      response.status shouldBe Status.OK
-      response.body[String] should startWith("#%RAML 1.0")
+    Seq(VERSION_1, VERSION_2).foreach { version  =>
+     s"return the documentation for $version" in {
+        val response: WSResponse = await(buildRequest(s"/api/conf/$version/application.raml").get())
+        response.status shouldBe Status.OK
+        response.body[String] should startWith(s"#%RAML 1.0")
+      }
     }
+
   }
 
 }

--- a/test/definition/VersionSpec.scala
+++ b/test/definition/VersionSpec.scala
@@ -19,14 +19,19 @@ package definition
 import play.api.http.HeaderNames.ACCEPT
 import play.api.test.FakeRequest
 import support.UnitSpec
+import Versions._
 
 class VersionSpec extends UnitSpec {
 
   "Versions" when {
-
-    "retrieved from a request header" must {
-      "work" in {
-        Versions.getFromRequest(FakeRequest().withHeaders((ACCEPT, "application/vnd.hmrc.1.0+json"))) shouldBe Some("1.0")
+    "retrieved from a request header" should {
+      Seq(
+        ("application/vnd.hmrc.1.0+json", VERSION_1),
+        ("application/vnd.hmrc.2.0+json", VERSION_2)
+      ).foreach { case (header, version) =>
+        s"return correct version $version" in {
+          Versions.getFromRequest(FakeRequest().withHeaders((ACCEPT, header))) shouldBe Some(version)
+        }
       }
     }
   }

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -47,8 +47,8 @@ trait MockAppConfig extends MockFactory {
     // API Config
     def featureSwitch: CallHandler[Option[Configuration]] = (mockAppConfig.featureSwitch _: () => Option[Configuration]).expects()
     def apiGatewayContext: CallHandler[String]            = (mockAppConfig.apiGatewayContext _: () => String).expects()
-    def apiStatus: CallHandler[String]                    = (mockAppConfig.apiStatus: String => String).expects("1.0")
-    def endpointsEnabled: CallHandler[Boolean]            = (mockAppConfig.endpointsEnabled: String => Boolean).expects("1.0")
+    def apiStatus(status: String): CallHandler[String]    = (mockAppConfig.apiStatus: String => String).expects(status)
+    def endpointsEnabled(version: String): CallHandler[Boolean] = (mockAppConfig.endpointsEnabled: String => Boolean).expects(version)
 
     def confidenceLevelCheckEnabled: CallHandler[ConfidenceLevelConfig] =
       (mockAppConfig.confidenceLevelConfig _: () => ConfidenceLevelConfig).expects()


### PR DESCRIPTION
Fix the build error and enable v2 endpoints in API definition (except ET/Prod envrionments).