### PR TITLE
MTDSA-22948: Deprecate APIs After Release 11

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -91,7 +91,6 @@ play.modules.enabled += "config.DIModule"
 
 # Api related config
 api {
-  documentation-url = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/self-assessment-accounts-api"
   # The status of the version of the API for the API Platform.
   2.0 {
     status = "DEPRECATED"
@@ -119,6 +118,7 @@ api {
 
   # The context which the API will have via the API Platform http://API_GATEWAY/{api.gateway.context}/
   gateway.context = "accounts/self-assessment"
+  documentation-url = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/self-assessment-accounts-api"
 }
 
 bootstrap.http.headersAllowlist = [ "Accept", "Gov-Test-Scenario", "Content-Type", "Location", "X-Request-Timestamp", "X-Session-Id" ]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -91,6 +91,7 @@ play.modules.enabled += "config.DIModule"
 
 # Api related config
 api {
+  documentation-url = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/self-assessment-accounts-api"
   # The status of the version of the API for the API Platform.
   2.0 {
     status = "DEPRECATED"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -96,7 +96,6 @@ api {
   2.0 {
     status = "DEPRECATED"
     deprecatedOn = "2023-05-03"
-    link = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/self-assessment-accounts-api/2.0/oas/page"
     endpoints{
         enabled = true
         api-released-in-production = true

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -94,7 +94,7 @@ api {
   # The status of the version of the API for the API Platform.
   2.0 {
     status = "DEPRECATED"
-    deprecatedOn = "03/05/2023"
+    deprecatedOn = "2023-05-03"
     link = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/self-assessment-accounts-api/2.0/oas/page"
     endpoints{
         enabled = true

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -93,7 +93,9 @@ play.modules.enabled += "config.DIModule"
 api {
   # The status of the version of the API for the API Platform.
   2.0 {
-    status = "BETA"
+    status = "DEPRECATED"
+    deprecatedOn = "03/05/2023"
+    link = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/self-assessment-accounts-api/2.0/oas/page"
     endpoints{
         enabled = true
         api-released-in-production = true

--- a/it/shared/controllers/DocumentationControllerISpec.scala
+++ b/it/shared/controllers/DocumentationControllerISpec.scala
@@ -56,7 +56,7 @@ class DocumentationControllerISpec extends IntegrationBaseSpec {
       |    "versions":[
       |      {
       |        "version":"2.0",
-      |        "status":"BETA",
+      |        "status":"DEPRECATED",
       |        "endpointsEnabled":true
       |      },
       |      {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.20.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.21.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.2.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"            % "2.8.18")
 addSbtPlugin("org.scalastyle"   %% "scalastyle-sbt-plugin" % "1.0.0")


### PR DESCRIPTION
- Adds documentation-url, deprecatedOn and link fields to the application.conf file.
- Modifies status from “BETA” to “DEPRECATED”