### PR TITLE
POC for CL436 - Create a new mandatory field changeTimestamp and deprecate existing field changeDate behind feature switches in codebase and docs.

### DIFF
--- a/app/shared/models/domain/Timestamp.scala
+++ b/app/shared/models/domain/Timestamp.scala
@@ -24,6 +24,8 @@ import java.time.{ZoneId, ZonedDateTime}
 
 case class Timestamp private (value: String) extends AnyVal {
   override def toString: String = value
+
+  def toDate: String =  ZonedDateTime.parse(value).toLocalDate.toString
 }
 
 object Timestamp {

--- a/app/v4/retrieveChargeHistoryByTransactionId/def1/models/response/ChargeHistoryDetail.scala
+++ b/app/v4/retrieveChargeHistoryByTransactionId/def1/models/response/ChargeHistoryDetail.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,10 @@ package v4.retrieveChargeHistoryByTransactionId.def1.models.response
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import shared.models.domain.TaxYear
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.models.domain.{TaxYear, Timestamp}
+
+import scala.util.Try
 
 case class ChargeHistoryDetail(taxYear: Option[String],
                                transactionId: String,
@@ -26,10 +29,15 @@ case class ChargeHistoryDetail(taxYear: Option[String],
                                description: String,
                                totalAmount: BigDecimal,
                                changeDate: String,
+                               changeTimestamp: Timestamp,
                                changeReason: String,
                                poaAdjustmentReason: Option[String])
 
 object ChargeHistoryDetail {
+
+  private def timestampConverter(str: String): Timestamp = Try(Timestamp(str)).getOrElse(
+    Timestamp(s"${str}T00:00:00.000Z")
+  )
 
   implicit val reads: Reads[ChargeHistoryDetail] =
     ((JsPath \ "taxYear").readNullable[String].map(_.map(TaxYear.fromDownstream(_).asMtd)) and
@@ -37,9 +45,13 @@ object ChargeHistoryDetail {
       (JsPath \ "documentDate").read[String] and
       (JsPath \ "documentDescription").read[String] and
       (JsPath \ "totalAmount").read[BigDecimal] and
-      (JsPath \ "reversalDate").read[String] and
+      (JsPath \ "reversalDate").read[String].map(timestampConverter(_).toDate) and
+      (JsPath \ "reversalDate").read[String].map(timestampConverter) and
       (JsPath \ "reversalReason").read[String] and
       (JsPath \ "poaAdjustmentReason").readNullable[String])(ChargeHistoryDetail.apply _)
 
-  implicit val writes: OWrites[ChargeHistoryDetail] = Json.writes[ChargeHistoryDetail]
+  implicit def writes(implicit appConfig: SharedAppConfig): OWrites[ChargeHistoryDetail] =
+    Json.writes[ChargeHistoryDetail].transform { jsonObject =>
+      if (ConfigFeatureSwitches().isEnabled("ifs_hip_migration_1554")) jsonObject else jsonObject - "changeTimestamp"
+    }
 }

--- a/app/v4/retrieveChargeHistoryByTransactionId/model/response/RetrieveChargeHistoryResponse.scala
+++ b/app/v4/retrieveChargeHistoryByTransactionId/model/response/RetrieveChargeHistoryResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package v4.retrieveChargeHistoryByTransactionId.model.response
 
 import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+import shared.config.SharedAppConfig
 import v4.retrieveChargeHistoryByTransactionId.def1.models.response.ChargeHistoryDetail
 
 case class RetrieveChargeHistoryResponse(chargeHistoryDetails: Seq[ChargeHistoryDetail])
@@ -28,5 +29,5 @@ object RetrieveChargeHistoryResponse  {
       .read[Seq[ChargeHistoryDetail]]
       .map(items => RetrieveChargeHistoryResponse(items))
 
-  implicit val writes: OWrites[RetrieveChargeHistoryResponse] = Json.writes[RetrieveChargeHistoryResponse]
+  implicit def writes(implicit appConfig: SharedAppConfig): OWrites[RetrieveChargeHistoryResponse] = Json.writes[RetrieveChargeHistoryResponse]
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -138,6 +138,8 @@ feature-switch {
   allowTemporalValidationSuspension.enabled = true
 
   ifs_hip_migration_1553.enabled = true
+  ifs_hip_migration_1554.enabled = true
+  ifs_hip_migration_1554_docs.released-in-production = false
 
   supporting-agents-access-control {
      enabled = true
@@ -174,8 +176,6 @@ microservice {
       token = ABCD1234
       environmentHeaders = ["Accept", "Gov-Test-Scenario", "Content-Type", "Location", "X-Request-Timestamp", "X-Session-Id", "X-Request-Id"]
     }
-
-
 
     hip {
       host = 127.0.0.1

--- a/it/test/v4/endpoints/retrieveChargeHistoryByTransactionId/def1/Def1_RetrieveChargeHistoryByTransactionIdSpec.scala
+++ b/it/test/v4/endpoints/retrieveChargeHistoryByTransactionId/def1/Def1_RetrieveChargeHistoryByTransactionIdSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers.AUTHORIZATION
 import shared.models.errors._
 import shared.services.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
 import shared.support.IntegrationBaseSpec
-import v4.retrieveChargeHistoryByChargeReference.def1.model.response.RetrieveChargeHistoryFixture.{downstreamResponseMultiple, mtdMultipleResponse}
+import v4.retrieveChargeHistoryByTransactionId.def1.RetrieveChargeHistoryFixture.{downstreamResponseMultiple, mtdMultipleResponse}
 
 class Def1_RetrieveChargeHistoryByTransactionIdSpec extends IntegrationBaseSpec {
 

--- a/resources/public/api/conf/4.0/examples/retrieveSelfAssementChargeHistory/def1/response.json
+++ b/resources/public/api/conf/4.0/examples/retrieveSelfAssementChargeHistory/def1/response.json
@@ -1,14 +1,15 @@
 {
   "chargeHistoryDetails": [
     {
-    "taxYear": "2022-23",
-    "transactionId": "X123456790A",
-    "transactionDate": "2018-04-05",
-    "description": "POA1, Balancing charge",
-    "totalAmount": 600.00,
-    "changeDate": "2018-04-05",
-    "changeReason": "Amended return, Customer Request",
-    "poaAdjustmentReason": "004"
+      "taxYear": "2022-23",
+      "transactionId": "X123456790A",
+      "transactionDate": "2018-04-05",
+      "description": "POA1, Balancing charge",
+      "totalAmount": 600.00,
+      "changeDate": "2018-04-05",
+      "changeTimestamp": "2018-04-05T14:15:22.802Z",
+      "changeReason": "Amended return, Customer Request",
+      "poaAdjustmentReason": "004"
     }
   ]
 }

--- a/resources/public/api/conf/4.0/schemas/retrieveSelfAssementChargeHistory/def1/response.json
+++ b/resources/public/api/conf/4.0/schemas/retrieveSelfAssementChargeHistory/def1/response.json
@@ -40,9 +40,17 @@
             "example": "600.00"
           },
           "changeDate": {
-            "description": "The date the charge was changed in the format: YYYY-MM-DD.",
+            "description": "The date the charge was changed in the format: YYYY-MM-DD. This field is deprecated and will be removed in a future release. Use changeTimestamp instead.",
             "type": "string",
-            "example": "2018-04-05"
+            "format": "date",
+            "example": "2018-04-05",
+            "deprecated": true
+          },
+          "changeTimestamp": {
+            "description": "{{#unless (releasedInProduction 'ifs_hip_migration_1554_docs')}}[Test only] {{/unless}}The timestamp the charge was changed in the format: YYYY-MM-DDThh:mm:ss.SSSZ",
+            "type": "string",
+            "format": "date-time",
+            "example": "2018-04-05T14:15:22.802Z"
           },
           "changeReason": {
             "description": "The reason for the change.",
@@ -60,6 +68,7 @@
           "transactionDate",
           "description",
           "totalAmount",
+          "changeTimestamp",
           "changeDate",
           "changeReason"
         ]

--- a/test/v4/retrieveChargeHistoryByTransactionId/RetrieveChargeHistoryByTransactionIdConnectorSpec.scala
+++ b/test/v4/retrieveChargeHistoryByTransactionId/RetrieveChargeHistoryByTransactionIdConnectorSpec.scala
@@ -20,10 +20,9 @@ import shared.connectors.ConnectorSpec
 import shared.models.domain.{Nino, TransactionId}
 import shared.models.outcomes.ResponseWrapper
 import uk.gov.hmrc.http.StringContextOps
+import v4.retrieveChargeHistoryByTransactionId.def1.RetrieveChargeHistoryFixture.validChargeHistoryResponseObject
 import v4.retrieveChargeHistoryByTransactionId.def1.models.request.Def1_RetrieveChargeHistoryByTransactionIdRequestData
-import v4.retrieveChargeHistoryByTransactionId.def1.models.response.ChargeHistoryDetail
 import v4.retrieveChargeHistoryByTransactionId.model.request.RetrieveChargeHistoryByTransactionIdRequestData
-import v4.retrieveChargeHistoryByTransactionId.model.response.RetrieveChargeHistoryResponse
 
 import scala.concurrent.Future
 
@@ -32,36 +31,19 @@ class RetrieveChargeHistoryByTransactionIdConnectorSpec extends ConnectorSpec {
   val nino: String          = "AA123456A"
   val transactionId: String = "anId"
 
-  val chargeHistoryDetails: ChargeHistoryDetail =
-    ChargeHistoryDetail(
-      taxYear = Some("2019-20"),
-      transactionId = "X123456790A",
-      transactionDate = "2019-06-01",
-      description = "Balancing Charge Debit",
-      totalAmount = 600.01,
-      changeDate = "2019-06-05",
-      changeReason = "Example reason",
-      poaAdjustmentReason = Some("002")
-    )
-
-  val retrieveChargeHistoryResponse: RetrieveChargeHistoryResponse =
-    RetrieveChargeHistoryResponse(
-      chargeHistoryDetails = List(chargeHistoryDetails)
-    )
-
   trait Test {  _: ConnectorTest =>
 
     val connector: RetrieveChargeHistoryByTransactionIdConnector =
       new RetrieveChargeHistoryByTransactionIdConnector(http = mockHttpClient, appConfig = mockSharedAppConfig)
   }
 
-  "RetrieveChargeHistoryConnector" when {
-    "retrieveChargeHistory" must {
+  "RetrieveChargeHistoryByTransactionIdConnector" when {
+    "retrieveChargeHistoryByTransactionId" must {
       "return a valid response" in new IfsTest with Test {
 
         val request: RetrieveChargeHistoryByTransactionIdRequestData =
           Def1_RetrieveChargeHistoryByTransactionIdRequestData(Nino(nino), TransactionId(transactionId))
-        private val outcome = Right(ResponseWrapper(correlationId, retrieveChargeHistoryResponse))
+        private val outcome = Right(ResponseWrapper(correlationId, validChargeHistoryResponseObject))
 
         willGet(
           url = url"$baseUrl/cross-regime/charges/NINO/$nino/ITSA",

--- a/test/v4/retrieveChargeHistoryByTransactionId/RetrieveChargeHistoryByTransactionIdControllerSpec.scala
+++ b/test/v4/retrieveChargeHistoryByTransactionId/RetrieveChargeHistoryByTransactionIdControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ class RetrieveChargeHistoryByTransactionIdControllerSpec
       idGenerator = mockIdGenerator
     )
 
-    MockedSharedAppConfig.featureSwitchConfig returns Configuration.empty
+    MockedSharedAppConfig.featureSwitchConfig.anyNumberOfTimes() returns Configuration.empty
     MockedSharedAppConfig.endpointAllowsSupportingAgents(controller.endpointName).anyNumberOfTimes() returns false
 
     protected def callController(): Future[Result] = controller.retrieveChargeHistoryByTransactionId(validNino, transactionId)(fakeGetRequest)

--- a/test/v4/retrieveChargeHistoryByTransactionId/RetrieveChargeHistoryByTransactionIdServiceSpec.scala
+++ b/test/v4/retrieveChargeHistoryByTransactionId/RetrieveChargeHistoryByTransactionIdServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,31 +20,13 @@ import shared.models.domain.{Nino, TransactionId}
 import shared.models.errors._
 import shared.models.outcomes.ResponseWrapper
 import shared.services.ServiceSpec
+import v4.retrieveChargeHistoryByTransactionId.def1.RetrieveChargeHistoryFixture.validChargeHistoryResponseObject
 import v4.retrieveChargeHistoryByTransactionId.def1.models.request.Def1_RetrieveChargeHistoryByTransactionIdRequestData
-import v4.retrieveChargeHistoryByTransactionId.def1.models.response.ChargeHistoryDetail
 import v4.retrieveChargeHistoryByTransactionId.model.request.RetrieveChargeHistoryByTransactionIdRequestData
-import v4.retrieveChargeHistoryByTransactionId.model.response.RetrieveChargeHistoryResponse
 
 import scala.concurrent.Future
 
 class RetrieveChargeHistoryByTransactionIdServiceSpec extends ServiceSpec {
-
-  val chargeHistoryDetails: ChargeHistoryDetail =
-    ChargeHistoryDetail(
-      taxYear = Some("2019-20"),
-      transactionId = "X123456790A",
-      transactionDate = "2019-06-01",
-      description = "Balancing Charge Debit",
-      totalAmount = 600.01,
-      changeDate = "2019-06-05",
-      changeReason = "Example reason",
-      poaAdjustmentReason = Some("001")
-    )
-
-  val retrieveChargeHistoryResponse: RetrieveChargeHistoryResponse =
-    RetrieveChargeHistoryResponse(
-      chargeHistoryDetails = List(chargeHistoryDetails)
-    )
 
   private val nino          = Nino("AA123456A")
   private val transactionId = TransactionId("anId")
@@ -55,50 +37,50 @@ class RetrieveChargeHistoryByTransactionIdServiceSpec extends ServiceSpec {
       transactionId = transactionId
     )
 
-  "RetrieveChargeHistoryService" should {
-    "service call successful" when {
+  "RetrieveChargeHistoryByTransactionIdService" when {
+    "service call successful" should {
       "return mapped result" in new Test {
         MockRetrieveChargeHistoryByTransactionIdConnector
           .retrieveChargeHistoryByTransactionId(requestData)
-          .returns(Future.successful(Right(ResponseWrapper(correlationId, retrieveChargeHistoryResponse))))
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, validChargeHistoryResponseObject))))
 
         private val result = await(service.retrieveChargeHistoryByTransactionId(requestData))
-        result shouldBe Right(ResponseWrapper(correlationId, retrieveChargeHistoryResponse))
+        result shouldBe Right(ResponseWrapper(correlationId, validChargeHistoryResponseObject))
       }
     }
-  }
 
-  "unsuccessful" must {
-    "map errors according to spec" when {
+    "unsuccessful" should {
+      "map errors according to spec" when {
 
-      def serviceError(downstreamErrorCode: String, error: MtdError): Unit =
-        s"a $downstreamErrorCode error is returned from the service" in new Test {
+        def serviceError(downstreamErrorCode: String, error: MtdError): Unit =
+          s"a $downstreamErrorCode error is returned from the service" in new Test {
 
-          MockRetrieveChargeHistoryByTransactionIdConnector
-            .retrieveChargeHistoryByTransactionId(requestData)
-            .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
+            MockRetrieveChargeHistoryByTransactionIdConnector
+              .retrieveChargeHistoryByTransactionId(requestData)
+              .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
 
-          await(service.retrieveChargeHistoryByTransactionId(requestData)) shouldBe Left(ErrorWrapper(correlationId, error))
-        }
+            await(service.retrieveChargeHistoryByTransactionId(requestData)) shouldBe Left(ErrorWrapper(correlationId, error))
+          }
 
-      val errors: Seq[(String, MtdError)] =
-        List(
-          "INVALID_CORRELATIONID" -> InternalError,
-          "INVALID_ID_TYPE"       -> InternalError,
-          "INVALID_IDVALUE"       -> NinoFormatError,
-          "INVALID_REGIME_TYPE"   -> InternalError,
-          "INVALID_DOC_NUMBER"    -> TransactionIdFormatError,
-          "INVALID_DATE_FROM"     -> InternalError,
-          "INVALID_DATE_TO"       -> InternalError,
-          "INVALID_DATE_RANGE"    -> InternalError,
-          "INVALID_REQUEST"       -> InternalError,
-          "REQUEST_NOT_PROCESSED" -> InternalError,
-          "NO_DATA_FOUND"         -> NotFoundError,
-          "SERVER_ERROR"          -> InternalError,
-          "SERVICE_UNAVAILABLE"   -> InternalError
-        )
+        val errors: Seq[(String, MtdError)] =
+          List(
+            "INVALID_CORRELATIONID" -> InternalError,
+            "INVALID_ID_TYPE"       -> InternalError,
+            "INVALID_IDVALUE"       -> NinoFormatError,
+            "INVALID_REGIME_TYPE"   -> InternalError,
+            "INVALID_DOC_NUMBER"    -> TransactionIdFormatError,
+            "INVALID_DATE_FROM"     -> InternalError,
+            "INVALID_DATE_TO"       -> InternalError,
+            "INVALID_DATE_RANGE"    -> InternalError,
+            "INVALID_REQUEST"       -> InternalError,
+            "REQUEST_NOT_PROCESSED" -> InternalError,
+            "NO_DATA_FOUND"         -> NotFoundError,
+            "SERVER_ERROR"          -> InternalError,
+            "SERVICE_UNAVAILABLE"   -> InternalError
+          )
 
-      errors.foreach(args => (serviceError _).tupled(args))
+        errors.foreach(args => (serviceError _).tupled(args))
+      }
     }
   }
 

--- a/test/v4/retrieveChargeHistoryByTransactionId/def1/RetrieveChargeHistoryFixture.scala
+++ b/test/v4/retrieveChargeHistoryByTransactionId/def1/RetrieveChargeHistoryFixture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 package v4.retrieveChargeHistoryByTransactionId.def1
 
 import play.api.libs.json.{JsValue, Json}
+import shared.models.domain.Timestamp
 import v4.retrieveChargeHistoryByTransactionId.def1.models.response.ChargeHistoryDetail
 import v4.retrieveChargeHistoryByTransactionId.model.response.RetrieveChargeHistoryResponse
-
 
 object RetrieveChargeHistoryFixture {
 
@@ -30,6 +30,7 @@ object RetrieveChargeHistoryFixture {
     description = "Balancing Charge",
     totalAmount = 54321.12,
     changeDate = "2020-02-24",
+    changeTimestamp = Timestamp("2020-02-24T14:15:22.802Z"),
     changeReason = "amended return",
     poaAdjustmentReason = Some("001")
   )
@@ -45,7 +46,7 @@ object RetrieveChargeHistoryFixture {
       |  "documentDate":"${validChargeHistoryDetailObject.transactionDate}",
       |  "documentDescription": "${validChargeHistoryDetailObject.description}",
       |  "totalAmount": ${validChargeHistoryDetailObject.totalAmount},
-      |  "reversalDate": "${validChargeHistoryDetailObject.changeDate}",
+      |  "reversalDate": "${validChargeHistoryDetailObject.changeTimestamp.value}",
       |  "reversalReason": "${validChargeHistoryDetailObject.changeReason}",
       |  "poaAdjustmentReason": "001"
       |}
@@ -83,6 +84,7 @@ object RetrieveChargeHistoryFixture {
       |  "description": "${validChargeHistoryDetailObject.description}",
       |  "totalAmount": ${validChargeHistoryDetailObject.totalAmount},
       |  "changeDate": "${validChargeHistoryDetailObject.changeDate}",
+      |  "changeTimestamp": "${validChargeHistoryDetailObject.changeTimestamp.value}",
       |  "changeReason": "${validChargeHistoryDetailObject.changeReason}",
       |  "poaAdjustmentReason": "001"
       |}


### PR DESCRIPTION
This POC is an example on how to handle the existing field changeDate which is a date field and introduce a new mandatory changeTimestamp which is a timestamp. This has been done behind a feature switch so the date will only be returned until the code feature switch is turned on where both of the fields will be present. However, in the docs when the docs feature switch is enabled, the changeDate field will be struck through and flagged as deprecated with a deprecated flag (see screenshot) with a comment added that the field is deprecated. Also the new field will be marked as Test only via the released-in-production flag until it is available in production. 

**Note:** **_This has only been implemented in the V4 Charge by transaction ID and will also need to be implemented for the Charge by charge reference in V4 and in V3 for both endpoints in the codebase._** Even though there is only code for Charge by transaction ID and Charge by charge reference, in the docs there are three endpoints i.e. **_Retrieve History of a Self Assessment Charge which reuses the Charge by transaction ID code_**. **Ensure the same OAS changes made for both Charge by transaction ID and Charge by charge reference is also done for Retrieve History of a Self Assessment Charge.**

<img width="869" height="1003" alt="doc" src="https://github.com/user-attachments/assets/a7b4a11f-ad82-4008-a002-54b2ead7247e" />

